### PR TITLE
Abstract template fetching

### DIFF
--- a/src/resource-manager.js
+++ b/src/resource-manager.js
@@ -182,19 +182,30 @@ class ResourceManager {
             return Promise.resolve();
         }
 
-        return fetch(path).then(function (resp) {
+        return this.fetchTemplate(path).then(function (contents) {
+            if (isHandlebarFile(path)) {
+                contents = Handlebars.compile(contents)(hbsData || {});
+            }
+            if (el) {
+                el.innerHTML = contents;
+                contents = el;
+            }
+            return contents;
+        })
+
+    }
+
+    /**
+     * Fetches a template file from the server.
+     * @param [templatePath] - The file path to the template file
+     * @returns {Promise} Returns a promise that is resolved with the contents of the template file when retrieved
+     */
+    fetchTemplate(templatePath) {
+        return fetch(templatePath).then(function (resp) {
             return resp.text().then(function (contents) {
-                if (isHandlebarFile(path)) {
-                    contents = Handlebars.compile(contents)(hbsData || {});
-                }
-                if (el) {
-                    el.innerHTML = contents;
-                    contents = el;
-                }
                 return contents;
             })
         });
-
     }
 
     /**

--- a/tests/resource-manager-tests.js
+++ b/tests/resource-manager-tests.js
@@ -256,4 +256,16 @@ describe('Resource Manager', function () {
             ResourceManager.flush();
         });
     });
+
+    it('fetchTemplate() should make fetch request with correct options and return proper text response', function () {
+        var path = 'test/path/to/css/single';
+        var templateHtml = '<div>mytext</div>';
+        var serverResp = {text: sinon.stub().returns(Promise.resolve(templateHtml))};
+        window.fetch.returns(Promise.resolve(serverResp));
+        return ResourceManager.fetchTemplate(path).then(function (html) {
+            assert.equal(window.fetch.args[0][0], path);
+            assert.equal(html, templateHtml);
+            ResourceManager.flush();
+        });
+    });
 });


### PR DESCRIPTION
This moves template fetching logic into its own method so that implementors can utilitize this functionality on its own.